### PR TITLE
Remove barrier.py file from Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,6 @@ ADD docker/apache-maven-3.6.3-bin.tar.gz /usr/local
 RUN ln -s /usr/local/apache-maven-3.6.3/bin/mvn /usr/local/bin
 COPY template_cpp /root/template_cpp
 COPY template_java /root/template_java
-ADD barrier.py /root
 
 RUN /root/template_cpp/build.sh && /root/template_cpp/cleanup.sh
 RUN /root/template_java/build.sh && /root/template_java/cleanup.sh


### PR DESCRIPTION
Adding the missing file barrier.py prevent the docker image to be built. So this instruction should be removed.